### PR TITLE
Don't reference the local path when adding includes

### DIFF
--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -79,7 +79,7 @@
 {% endif %}
 
 {% if samba_global_include is defined %}
-  include = {{ samba_configuration_dir }}/{{ samba_global_include }}
+  include = {{ samba_configuration_dir }}/{{ samba_global_include | basename }}
 {% endif %}
 
 {% if samba_load_homes %}
@@ -138,7 +138,7 @@
   directory mode = {{ share.directory_mode|default('0775') }}
   force directory mode = {{ share.force_directory_mode|default('0775') }}
 {% if share.include_file is defined %}
-  include = {{ samba_configuration_dir }}/{{ share.include_file }}
+  include = {{ samba_configuration_dir }}/{{ share.include_file | basename }}
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
When include files are not at the top-level, the path is added to the include directives in smb.conf. However, the template task does not include this path, so the resulting smb.conf is invalid. This PR changes the smb.conf template to not include the local path to the include files.