### PR TITLE
Improve RedHat support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,10 @@ jobs:
           - ubuntu2004
           - debian11
           - debian10
-          - centos8
           - fedora36
           - fedora37
+          - rockylinux8
+          - rockylinux9
         scenario: ${{ fromJSON(needs.changes.outputs.scenario) }}
     steps:
       - name: Checkout

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,8 +13,6 @@
         - usr2
         - timemachine
   vars:
-    ansible_selinux:
-      status: enabled
     samba_netbios_name: NAS
     samba_server_string: NAS
     samba_workgroup: WORKGROUP

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,6 +13,8 @@
         - usr2
         - timemachine
   vars:
+    ansible_selinux:
+      status: enabled
     samba_netbios_name: NAS
     samba_server_string: NAS
     samba_workgroup: WORKGROUP

--- a/roles/server/meta/main.yml
+++ b/roles/server/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Bert Van Vreckem
+  author: Vlad Ghinea and Bert Van Vreckem
   description: This role installs and configures Samba as a file server.
   license: BSD
   min_ansible_version: '2.11'
@@ -13,6 +13,17 @@ galaxy_info:
       versions:
         - bullseye
         - buster
+    - name: Fedora
+      versions:
+        - '36'
+        - '37'
+    - name: EL
+      versions:
+        - '8'
+        - '9'
+    - name: ArchLinux
+      versions:
+        - all
   galaxy_tags:
     - system
     - networking

--- a/roles/server/vars/os_RedHat.yml
+++ b/roles/server/vars/os_RedHat.yml
@@ -8,7 +8,7 @@ samba_packages:
 samba_vfs_packages: []
 
 samba_selinux_packages:
-  - libsemanage-python
+  - python3-libsemanage
 
 samba_selinux_booleans:
   - samba_enable_home_dirs


### PR DESCRIPTION
This PR ensures support for Fedora 36 & 37, as well as RockyLinux 8 and 9.
Closes #38 & #39 