### PR TITLE
smb.conf.j2 template improperly compares running Samba version

### DIFF
--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -1,7 +1,7 @@
 # Samba configuration -- Managed by Ansible, please don't edit manually
 # vim: ft=samba
 #
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [global]
   # Server information
@@ -72,7 +72,7 @@
   {% endif %}
 {% endif %}
 
-{% if samba_mitigate_cve_2017_7494 and samba_version.stdout >= "3.5.0" and samba_version.stdout < "4.6.4" %}
+{% if samba_mitigate_cve_2017_7494 and samba_version.stdout is version('3.5.0', '>=') and samba_version.stdout is version('4.6.4', '<') %}
   # Fix for CVE-2017-7494 in Samba versions from 3.5.0 and before 4.6.4
   # https://access.redhat.com/security/cve/cve-2017-7494
   nt pipe support = no


### PR DESCRIPTION
Per: https://github.com/vladgh/ansible-collection-vladgh-samba/issues/56

Line 75 of `roles/server/templates/smb.conf.j2` attempts to compare string values of the running Samba version. Unfortunately this comparison doesn't operate as intended, causing CVE mitigation to occur in situations it shouldn't. The side effect of the nt pipe support = no setting causes MacOS clients, and possibly others, to not be able to browse shares, only mount them directly (which can be quite disruptive and confusing!)

Replaces the line:
`{% if samba_mitigate_cve_2017_7494 and samba_version.stdout >= "3.5.0" and samba_version.stdout < "4.6.4" %}`

With:
`{% if samba_mitigate_cve_2017_7494 and samba_version.stdout is version('3.5.0', '>=') and samba_version.stdout is version('4.6.4', '<') %}`

Also cleans up `{{ ansible_managed }}` near the top to handle multi-line ansible_managed strings.