### PR TITLE
Fix samba_vfs_packages on Archlinux

### DIFF
--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.package:
     name: "{{ samba_vfs_packages }}"
     state: present
-  when: samba_vfs_packages is defined
+  when: samba_vfs_packages is defined and samba_vfs_packages | length > 0
   tags: samba
 
 - name: Register Samba version


### PR DESCRIPTION
On Archlinux, samba_vfs_packages is defined but empty. Add the check for an empty list.