### PR TITLE
Archlinux fixes

### DIFF
--- a/roles/server/vars/os_Archlinux.yml
+++ b/roles/server/vars/os_Archlinux.yml
@@ -15,7 +15,7 @@ samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
 samba_services:
-  - smbd
-  - nmbd
+  - smb
+  - nmb
 
 samba_www_documentroot: /var/www


### PR DESCRIPTION
Should have checked it was all working before the last PR... which it is now, after:
- Correct the service names (no `d` suffix)
- Add `enabled: true` to ensure the required services start on boot