### PR TITLE
Correctly enforce `samba_interfaces` option

### DIFF
--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -46,7 +46,8 @@
 
 {% endif %}
 {% if samba_interfaces|length > 0 %}
-  interfaces = {{ samba_interfaces }}
+  bind interfaces only = yes
+  interfaces = 127.0.0.1 {{ samba_interfaces|join(' ') }}
 
 {% endif %}
   # Name resolution: make sure \\NETBIOS_NAME\ works


### PR DESCRIPTION
Based on https://github.com/bertvv/ansible-role-samba/pull/77