### PR TITLE
Remove SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 An Ansible collection for setting up Samba as a file server. It is tested on Ubuntu, Debian, CentOS and Arch Linux. Specifically, the responsibilities of this collection are to:
 
 - Install the necessary packages
-- Configure SELinux settings (when SELinux is active)
 - Create share directories
 - Manage Samba users and passwords
 - Manage access to shares
@@ -213,7 +212,7 @@ A complete overview of share options follows below. Only `name` is required, the
 | `path`                 | `/{{samba_shares_root}}/{{name}}` | The path to the share directory.                                                               |
 | `public`               | `no`                            | Controls read access for guest users                                                           |
 | `read_only`               | -                            | If this parameter is yes, then users of a service may not create or modify files in the service's directory.                        |
-| `setype`               | `samba_share_t`                 | The SELinux type of the share directory                                                        |
+| `setype`               | -                 | The SELinux type of the share directory                                                        |
 | `user`                 | -                               | The user files in the share will be added to. (force user)                                     |
 | `valid_users`          | -                               | Controls read access for registered users. Use the syntax of the corresponding Samba setting.  |
 | `vfs_objects`          | -                               | See the Samba documentation for details.                                                       |
@@ -269,7 +268,7 @@ The [test playbook](molecule/default/converge.yml) has some examples.
 
 ## Dependencies
 
-- [Ansible Posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/)
+N/A
 
 ## Testing
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,8 +12,7 @@ tags:
   - samba
   - system
   - networking
-dependencies:
-  ansible.posix: "*"
+dependencies: {}
 repository: https://github.com/vladgh/ansible-collection-vladgh-samba
 documentation: https://github.com/vladgh/ansible-collection-vladgh-samba
 homepage: https://github.com/vladgh/ansible-collection-vladgh-samba

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -59,7 +59,6 @@
             public: 'yes'
             write_list: +users
             group: users
-            setype: public_content_t
             browseable: 'yes'
           - name: guestshare
             comment: 'Share accessible for guests'

--- a/roles/server/meta/main.yml
+++ b/roles/server/meta/main.yml
@@ -15,12 +15,12 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - '37'
         - '38'
+        - '37'
     - name: EL
       versions:
-        - '8'
         - '9'
+        - '8'
     - name: ArchLinux
       versions:
         - all

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -34,22 +34,6 @@
   changed_when: false
   tags: samba
 
-- name: Install SELinux package
-  ansible.builtin.package:
-    name: "{{ samba_selinux_packages }}"
-    state: present
-  when: ansible_selinux is defined and ansible_selinux.status == 'enabled'
-  tags: samba
-
-- name: Make sure SELinux boolean settings are correct
-  ansible.posix.seboolean:
-    name: "{{ item }}"
-    state: true
-    persistent: true
-  loop: "{{ samba_selinux_booleans }}"
-  when: ansible_selinux is defined and ansible_selinux.status == 'enabled'
-  tags: samba
-
 - name: Create Samba shares root directory
   ansible.builtin.file:
     state: directory
@@ -67,7 +51,7 @@
     owner: "{{ item.owner | default('root') }}"
     group: "{{ item.group | default('users') }}"
     mode: "{{ item.directory_mode | default('0775') }}"
-    setype: "{{ item.setype | default('samba_share_t') }}"
+    setype: "{{ item.setype | default(omit) }}"
   loop: "{{ samba_shares }}"
   when: samba_shares is defined and samba_shares | length > 0
   tags: samba

--- a/roles/server/vars/os_Archlinux.yml
+++ b/roles/server/vars/os_Archlinux.yml
@@ -1,13 +1,9 @@
 ---
-
 samba_packages:
   - samba
   - smbclient
 
 samba_vfs_packages: []
-
-samba_selinux_packages: []
-samba_selinux_booleans: []
 
 samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"

--- a/roles/server/vars/os_Debian.yml
+++ b/roles/server/vars/os_Debian.yml
@@ -1,14 +1,10 @@
 ---
-
 samba_packages:
   - samba
   - smbclient
 
 samba_vfs_packages:
   - samba-vfs-modules
-
-samba_selinux_packages: []
-samba_selinux_booleans: []
 
 samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"

--- a/roles/server/vars/os_RedHat.yml
+++ b/roles/server/vars/os_RedHat.yml
@@ -1,17 +1,9 @@
 ---
-
 samba_packages:
   - samba
   - samba-client
 
 samba_vfs_packages: []
-
-samba_selinux_packages:
-  - python3-libsemanage
-
-samba_selinux_booleans:
-  - samba_enable_home_dirs
-  - samba_export_all_rw
 
 samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"


### PR DESCRIPTION
I think it would be best to decouple SELinux labels from this role. It's not an essential functionality and it should be managed separately with a "hardening" role, for example https://github.com/dev-sec/ansible-collection-hardening. This role is well-maintained and has a good track record.

Addresses #74 