### PR TITLE
Add samba_disable_netbios and + split Samba services (re)starting into separate tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alternatively, you can directly import the existing playbook:
 | `samba_apple_extensions`       | `no`                       | When yes, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)       |
 | `samba_create_varwww_symlinks` | `false`                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
 | `samba_cups_server`            | `localhost:631`            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                                  |
-| `samba_disable_netbios`        | `false`                  | When true, the NMB daemon is disabled. This overrides other NetBIOS related settings.                                        |
+| `samba_enable_netbios`         | `true`                   | When false, the NMB daemon is disabled by setting `disable netbios` to `yes`. This overrides other NetBIOS related settings. |
 | `samba_domain_master`          | `true`                     | When true, smbd enables WAN-wide browse list collation                                                                       |
 | `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to [global] section (see below)                                |
 | `samba_guest_account`          | -                        | Guest account for unknown users                                                                                              |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Alternatively, you can directly import the existing playbook:
 | `samba_apple_extensions`       | `no`                       | When yes, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)       |
 | `samba_create_varwww_symlinks` | `false`                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
 | `samba_cups_server`            | `localhost:631`            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                                  |
+| `samba_disable_netbios`        | `false`                  | When true, the NMB daemon is disabled. This overrides other NetBIOS related settings.                                        |
 | `samba_domain_master`          | `true`                     | When true, smbd enables WAN-wide browse list collation                                                                       |
 | `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to [global] section (see below)                                |
 | `samba_guest_account`          | -                        | Guest account for unknown users                                                                                              |

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -18,7 +18,7 @@ samba_manage_directories: true
 samba_shares: []
 samba_users: []
 
-samba_disable_netbios: 'no'
+samba_enable_netbios: 'yes'
 samba_wins_support: 'yes'
 samba_local_master: 'yes'
 samba_domain_master: 'yes'

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -18,6 +18,7 @@ samba_manage_directories: true
 samba_shares: []
 samba_users: []
 
+samba_disable_netbios: 'no'
 samba_wins_support: 'yes'
 samba_local_master: 'yes'
 samba_domain_master: 'yes'

--- a/roles/server/handlers/main.yml
+++ b/roles/server/handlers/main.yml
@@ -8,4 +8,4 @@
   ansible.builtin.service:
     name: "{{ nmb_service }}"
     state: restarted
-  when: not samba_disable_netbios
+  when: samba_enable_netbios

--- a/roles/server/handlers/main.yml
+++ b/roles/server/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
-- name: Restart Samba services
+- name: Restart SMB service
   ansible.builtin.service:
-    name: "{{ item }}"
+    name: "{{ smb_service }}"
     state: restarted
-  loop: "{{ samba_services }}"
+
+- name: Restart NMB service
+  ansible.builtin.service:
+    name: "{{ nmb_service }}"
+    state: restarted
+  when: not samba_disable_netbios

--- a/roles/server/handlers/main.yml
+++ b/roles/server/handlers/main.yml
@@ -8,4 +8,4 @@
   ansible.builtin.service:
     name: "{{ nmb_service }}"
     state: restarted
-  when: samba_enable_netbios
+  when: samba_enable_netbios | bool

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -84,7 +84,8 @@
     validate: 'testparm -s %s'
     mode: '0644'
   notify:
-    - Restart Samba services
+    - Restart SMB service
+    - Restart NMB service
   tags: samba
 
 - name: Install global include file
@@ -95,7 +96,8 @@
     mode: '0644'
   when: samba_global_include is defined and samba_global_include
   notify:
-    - Restart Samba services
+    - Restart SMB service
+    - Restart NMB service
   tags: samba
 
 - name: Install home include file
@@ -106,7 +108,8 @@
     mode: '0644'
   when: samba_homes_include is defined and samba_homes_include
   notify:
-    - Restart Samba services
+    - Restart SMB service
+    - Restart NMB service
   tags: samba
 
 - name: Install share specific include files
@@ -120,7 +123,8 @@
         ( item.include_file is defined and item.include_file )
   loop: "{{ samba_shares }}"
   notify:
-    - Restart Samba services
+    - Restart SMB service
+    - Restart NMB service
   tags: samba
 
 - name: Create username map file if needed
@@ -129,7 +133,8 @@
     src: smbusers.j2
     mode: '0644'
   notify:
-    - Restart Samba services
+    - Restart SMB service
+    - Restart NMB service
   when: samba_username_map is defined and samba_username_map
   tags: samba
 

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -133,13 +133,20 @@
   when: samba_username_map is defined and samba_username_map
   tags: samba
 
-- name: Start Samba service(s)
+- name: Start SMB service
   ansible.builtin.service:
-    name: "{{ item }}"
+    name: "{{ smb_service }}"
     state: started
     enabled: true
-  loop: "{{ samba_services }}"
   tags: samba
+
+- name: Start NMB service
+  ansible.builtin.service:
+    name: "{{ nmb_service }}"
+    state: started
+    enabled: true
+  tags: samba
+  when: not samba_disable_netbios
 
 - name: Create Samba users if they don't exist yet
   ansible.builtin.shell: >

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -146,7 +146,7 @@
     state: started
     enabled: true
   tags: samba
-  when: not samba_disable_netbios
+  when: samba_enable_netbios
 
 - name: Create Samba users if they don't exist yet
   ansible.builtin.shell: >

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -146,7 +146,7 @@
     state: started
     enabled: true
   tags: samba
-  when: samba_enable_netbios
+  when: samba_enable_netbios | bool
 
 - name: Create Samba users if they don't exist yet
   ansible.builtin.shell: >

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -48,7 +48,10 @@
   interfaces = 127.0.0.1 {{ samba_interfaces | join(' ') }}
 
 {% endif %}
-  # Name resolution: make sure \\NETBIOS_NAME\ works
+  # Name resolution
+{% if samba_disable_netbios %}
+  disable netbios = yes
+{% endif %}
   wins support = {{ samba_wins_support | ternary('yes', 'no') }}
   local master = {{ samba_local_master | ternary('yes', 'no') }}
   domain master = {{ samba_domain_master | ternary('yes', 'no') }}

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -49,7 +49,7 @@
 
 {% endif %}
   # Name resolution
-{% if samba_disable_netbios %}
+{% if not samba_enable_netbios %}
   disable netbios = yes
 {% endif %}
   wins support = {{ samba_wins_support | ternary('yes', 'no') }}

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -49,7 +49,7 @@
 
 {% endif %}
   # Name resolution
-{% if not samba_enable_netbios %}
+{% if not samba_enable_netbios | bool %}
   disable netbios = yes
 {% endif %}
   wins support = {{ samba_wins_support | ternary('yes', 'no') }}

--- a/roles/server/vars/os_Archlinux.yml
+++ b/roles/server/vars/os_Archlinux.yml
@@ -9,8 +9,7 @@ samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
-samba_services:
-  - smb
-  - nmb
+smb_service: smb
+nmb_service: nmb
 
 samba_www_documentroot: /var/www

--- a/roles/server/vars/os_Debian.yml
+++ b/roles/server/vars/os_Debian.yml
@@ -10,8 +10,7 @@ samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
-samba_services:
-  - smbd
-  - nmbd
+smb_service: smbd
+nmb_service: nmbd
 
 samba_www_documentroot: /var/www

--- a/roles/server/vars/os_RedHat.yml
+++ b/roles/server/vars/os_RedHat.yml
@@ -9,8 +9,7 @@ samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
-samba_services:
-  - smb
-  - nmb
+smb_service: smb
+nmb_service: nmb
 
 samba_www_documentroot: /var/www/html


### PR DESCRIPTION
When `samba_disable_netbios` is true, `disable netbios = yes` is added to `smb.conf`. This overrides the other NetBIOS related `smb.conf` variables, so in theory we could forego adding those to `smb.conf`, but I don't know enough about Samba to know which variables only affect NetBIOS and can therefore be left out, so I left that out of this PR.