### PR TITLE
Get Samba version in check mode

### DIFF
--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -32,6 +32,7 @@
     executable: /bin/bash
   register: samba_version
   changed_when: false
+  check_mode: false
   tags: samba
 
 - name: Create Samba shares root directory


### PR DESCRIPTION
Adds `check_mode: false` to the Samba version check task in order to fix check mode functionality.

This fixes #121 