### PR TITLE
Documentation enhancements (Typos, Links, Punctuation, Formatting) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,39 +97,39 @@ Alternatively, you can directly import the existing playbook:
 
 | Variable                       | Default                  | Comments                                                                                                                     |
 | :---                           | :---                     | :---                                                                                                                         |
-| `samba_apple_extensions`       | `true`                       | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below).       |
-| `samba_create_varwww_symlinks` | `false`                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform.) |
-| `samba_cups_server`            | `localhost:631`            | Value for the global option `cups server`. (Only needed when `samba_printer_type` is "cups".)                                  |
+| `samba_apple_extensions`       | `true`                   | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below).         |
+| `samba_create_varwww_symlinks` | `false`                  | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform.)         |
+| `samba_cups_server`            | `localhost:631`          | Value for the global option `cups server`. (Only needed when `samba_printer_type` is "cups".)                                |
 | `samba_enable_netbios`         | `true`                   | When false, the NMB daemon is disabled by setting `disable netbios` to `yes`. This overrides other NetBIOS related settings. |
-| `samba_domain_master`          | `true`                     | When true, smbd enables WAN-wide browse list collation.                                                                      |
+| `samba_domain_master`          | `true`                   | When true, smbd enables WAN-wide browse list collation.                                                                      |
 | `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to `[global]` section (see below).                             |
 | `samba_guest_account`          | -                        | Guest account for unknown users.                                                                                             |
 | `samba_homes_include`          | -                        | Samba-compatible configuration file with options to be loaded to `[homes]` section (see below).                              |
-| `samba_interfaces`             | `[]`                       | List of network interfaces used for browsing, name registration, etc.                                                        |
-| `samba_load_homes`             | `false`                    | When true, user home directories are accessible.                                                                             |
-| `samba_load_printers`          | `false`                    | When true, printers attached to the host are shared.                                                                         |
-| `samba_local_master`           | `true`                     | When true, nmbd will try & become local master of the subnet.                                                                |
+| `samba_interfaces`             | `[]`                     | List of network interfaces used for browsing, name registration, etc.                                                        |
+| `samba_load_homes`             | `false`                  | When true, user home directories are accessible.                                                                             |
+| `samba_load_printers`          | `false`                  | When true, printers attached to the host are shared.                                                                         |
+| `samba_local_master`           | `true`                   | When true, nmbd will try & become local master of the subnet.                                                                |
 | `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                         |
-| `samba_log_size`               | `5000`                     | Set the maximum size of the log file.                                                                                        |
-| `samba_log_level`              | `0`                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
+| `samba_log_size`               | `5000`                   | Set the maximum size of the log file.                                                                                        |
+| `samba_log_level`              | `0`                      | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
 | `samba_map_to_guest`           | `Never`                  | Behaviour when unregistered users access the shares.                                                                         |
-| `samba_mitigate_cve_2017_7494` | `true`                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
-| `samba_mdns_name`              | `netbios`                  | The name advertised via multicast DNS.                                                                                             |
+| `samba_mitigate_cve_2017_7494` | `true`                   | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
+| `samba_mdns_name`              | `netbios`                | The name advertised via multicast DNS.                                                                                       |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                                   |
-| `samba_preferred_master`       | `true`                     | When true, indicates nmbd is a preferred master browser for workgroup.                                                       |
+| `samba_preferred_master`       | `true`                   | When true, indicates nmbd is a preferred master browser for workgroup.                                                       |
 | `samba_realm`                  | -                        | Realm domain name.                                                                                                           |
-| `samba_printer_type`           | `cups`                     | value for the global option `printing` and `printcap name`.                                                                  |
+| `samba_printer_type`           | `cups`                   | value for the global option `printing` and `printcap name`.                                                                  |
 | `samba_security`               | `user`                   | Samba security setting.                                                                                                      |
 | `samba_server_max_protocol`    | -                        | Specify a maximum protocol version offered by the server.                                                                    |
 | `samba_server_min_protocol`    | -                        | Specify a minimum protocol version offered by the server.                                                                    |
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                                                                               |
 | `samba_shares_root`            | `/srv/shares`            | Directories for the shares are created under this directory.                                                                 |
 | `samba_manage_directories`     | `true`                   | Create the directories, and manage the permissions/ownership, of the shares root and the shares under it.                    |
-| `samba_shares`                 | `[]`                       | List of dicts containing share definitions. See below for details.                                                           |
-| `samba_username_map`           | `[]`                       | Makes username map configurable.                                                                         |
-| `samba_users`                  | `[]`                       | List of dicts defining users that can access shares.                                                                         |
-| `samba_wins_support`           | `true`                     | When true, Samba will act as a WINS server.                                                                                  |
+| `samba_shares`                 | `[]`                     | List of dicts containing share definitions. See below for details.                                                           |
+| `samba_username_map`           | `[]`                     | Makes username map configurable.                                                                                             |
+| `samba_users`                  | `[]`                     | List of dicts defining users that can access shares.                                                                         |
+| `samba_wins_support`           | `true`                   | When true, Samba will act as a WINS server.                                                                                  |
 | `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                                                                                |
 
 ### Defining users
@@ -214,30 +214,30 @@ samba_shares:
 
 A complete overview of share options follows below. Only `name` is required, the rest is optional.
 
-| Option                 | Default                         | Comment                                                                                        |
-| :---                   | :---                            | :---                                                                                           |
-| `browsable`           | -                               | Synonym for `browseable`.                                           |
-| `browseable`           | -                               | Controls whether this share appears in file browser.                                           |
-| `comment`              | -                               | A comment string for the share.                                                                 |
-| `create_mode`          | `0664`                          | See the Samba documentation for details.                                                       |
-| `directory_mode`       | `0775`                          | See the Samba documentation for details.                                                       |
-| `include_file`         | -                               | Samba combatible configuration file with options to be included for this share (see below).    |
-| `force_create_mode`    | `0664`                          | See the Samba documentation for details.                                                       |
-| `force_directory_mode` | `0775`                          | See the Samba documentation for details.                                                       |
-| `group`                | `users`                         | The user group files in the share will be added to (share option `force group`).               |
-| `guest_ok`             | -                               | Allow guest access.                                                                            |
-| `name` (required)      | -                               | The name of the share.                                                                         |
-| `owner`                | `root`                          | Set the owner of the path.                                                                      |
-| `path`                 | `/{{samba_shares_root}}/{{name}}` | The path to the share directory.                                                               |
-| `public`               | `false`                            | Controls read access for guest users.                                                           |
-| `read_only`               | -                            | If this parameter is yes, then users of a service may not create or modify files in the service's directory.                        |
-| `setype`               | -                 | The SELinux type of the share directory.                                                        |
-| `user`                 | -                               | The user files in the share will be added to (share option `force user`).                      |
-| `valid_users`          | -                               | Controls read access for registered users. Use the syntax of the corresponding Samba setting.  |
-| `vfs_objects`          | -                               | See the Samba documentation for details.                                                       |
-| `writable`             | -                               | Synonym for `writeable`.                                                                           |
-| `writeable`             | -                               | Controls whether this share is writeable for guests.                                         |
-| `write_list`           | -                               | Controls write access for registered users. Use the syntax of the corresponding Samba setting. |
+| Option                 | Default                           | Comment                                                                                                      |
+| :---                   | :---                              | :---                                                                                                         |
+| `browsable`            | -                                 | Synonym for `browseable`.                                                                                    |
+| `browseable`           | -                                 | Controls whether this share appears in file browser.                                                         |
+| `comment`              | -                                 | A comment string for the share.                                                                              |
+| `create_mode`          | `0664`                            | See the Samba documentation for details.                                                                     |
+| `directory_mode`       | `0775`                            | See the Samba documentation for details.                                                                     |
+| `include_file`         | -                                 | Samba combatible configuration file with options to be included for this share (see below).                  |
+| `force_create_mode`    | `0664`                            | See the Samba documentation for details.                                                                     |
+| `force_directory_mode` | `0775`                            | See the Samba documentation for details.                                                                     |
+| `group`                | `users`                           | The user group files in the share will be added to (share option `force group`).                             |
+| `guest_ok`             | -                                 | Allow guest access.                                                                                          |
+| `name` (required)      | -                                 | The name of the share.                                                                                       |
+| `owner`                | `root`                            | Set the owner of the path.                                                                                   |
+| `path`                 | `/{{samba_shares_root}}/{{name}}` | The path to the share directory.                                                                             |
+| `public`               | `false`                           | Controls read access for guest users.                                                                        |
+| `read_only`            | -                                 | If this parameter is yes, then users of a service may not create or modify files in the service's directory. |
+| `setype`               | -                                 | The SELinux type of the share directory.                                                                     |
+| `user`                 | -                                 | The user files in the share will be added to (share option `force user`).                                    |
+| `valid_users`          | -                                 | Controls read access for registered users. Use the syntax of the corresponding Samba setting.                |
+| `vfs_objects`          | -                                 | See the Samba documentation for details.                                                                     |
+| `writable`             | -                                 | Synonym for `writeable`.                                                                                     |
+| `writeable`            | -                                 | Controls whether this share is writeable for guests.                                                         |
+| `write_list`           | -                                 | Controls write access for registered users. Use the syntax of the corresponding Samba setting.               |
 
 The values for `valid_users` and `write_list` should be a comma separated list of users. Names prepended with `+` or `@` are interpreted as groups. The documentation for the [Samba configuration](https://www.samba.org/samba/docs/man/manpages-3/smb.conf.5.html) has more details on these options.
 

--- a/README.md
+++ b/README.md
@@ -97,18 +97,18 @@ Alternatively, you can directly import the existing playbook:
 
 | Variable                       | Default                  | Comments                                                                                                                     |
 | :---                           | :---                     | :---                                                                                                                         |
-| `samba_apple_extensions`       | `true`                       | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)       |
-| `samba_create_varwww_symlinks` | `false`                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
-| `samba_cups_server`            | `localhost:631`            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                                  |
+| `samba_apple_extensions`       | `true`                       | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below).       |
+| `samba_create_varwww_symlinks` | `false`                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform.) |
+| `samba_cups_server`            | `localhost:631`            | Value for the global option `cups server`. (Only needed when `samba_printer_type` is "cups".)                                  |
 | `samba_enable_netbios`         | `true`                   | When false, the NMB daemon is disabled by setting `disable netbios` to `yes`. This overrides other NetBIOS related settings. |
-| `samba_domain_master`          | `true`                     | When true, smbd enables WAN-wide browse list collation                                                                       |
-| `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to [global] section (see below)                                |
-| `samba_guest_account`          | -                        | Guest account for unknown users                                                                                              |
-| `samba_homes_include`          | -                        | Samba-compatible configuration file with options to be loaded to [homes] section (see below)                                 |
+| `samba_domain_master`          | `true`                     | When true, smbd enables WAN-wide browse list collation.                                                                      |
+| `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to `[global]` section (see below).                             |
+| `samba_guest_account`          | -                        | Guest account for unknown users.                                                                                             |
+| `samba_homes_include`          | -                        | Samba-compatible configuration file with options to be loaded to `[homes]` section (see below).                              |
 | `samba_interfaces`             | `[]`                       | List of network interfaces used for browsing, name registration, etc.                                                        |
 | `samba_load_homes`             | `false`                    | When true, user home directories are accessible.                                                                             |
-| `samba_load_printers`          | `false`                    | When true, printers attached to the host are shared                                                                          |
-| `samba_local_master`           | `true`                     | When true, nmbd will try & become local master of the subnet                                                                 |
+| `samba_load_printers`          | `false`                    | When true, printers attached to the host are shared.                                                                         |
+| `samba_local_master`           | `true`                     | When true, nmbd will try & become local master of the subnet.                                                                |
 | `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                         |
 | `samba_log_size`               | `5000`                     | Set the maximum size of the log file.                                                                                        |
 | `samba_log_level`              | `0`                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
@@ -117,10 +117,10 @@ Alternatively, you can directly import the existing playbook:
 | `samba_mdns_name`              | `netbios`                  | The name advertised via multicast DNS.                                                                                             |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                                   |
-| `samba_preferred_master`       | `true`                     | When true, indicates nmbd is a preferred master browser for workgroup                                                        |
-| `samba_realm`                  | -                        | Realm domain name                                                                                                            |
-| `samba_printer_type`           | `cups`                     | value for the global option `printing` and `printcap name`                                                                   |
-| `samba_security`               | `user`                   | Samba security setting                                                                                                       |
+| `samba_preferred_master`       | `true`                     | When true, indicates nmbd is a preferred master browser for workgroup.                                                       |
+| `samba_realm`                  | -                        | Realm domain name.                                                                                                           |
+| `samba_printer_type`           | `cups`                     | value for the global option `printing` and `printcap name`.                                                                  |
+| `samba_security`               | `user`                   | Samba security setting.                                                                                                      |
 | `samba_server_max_protocol`    | -                        | Specify a maximum protocol version offered by the server.                                                                    |
 | `samba_server_min_protocol`    | -                        | Specify a minimum protocol version offered by the server.                                                                    |
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                                                                               |
@@ -129,7 +129,7 @@ Alternatively, you can directly import the existing playbook:
 | `samba_shares`                 | `[]`                       | List of dicts containing share definitions. See below for details.                                                           |
 | `samba_username_map`           | `[]`                       | Makes username map configurable.                                                                         |
 | `samba_users`                  | `[]`                       | List of dicts defining users that can access shares.                                                                         |
-| `samba_wins_support`           | `true`                     | When true, Samba will act as a WINS server                                                                                   |
+| `samba_wins_support`           | `true`                     | When true, Samba will act as a WINS server.                                                                                  |
 | `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                                                                                |
 
 ### Defining users
@@ -218,25 +218,25 @@ A complete overview of share options follows below. Only `name` is required, the
 | :---                   | :---                            | :---                                                                                           |
 | `browsable`           | -                               | Synonym for `browseable`.                                           |
 | `browseable`           | -                               | Controls whether this share appears in file browser.                                           |
-| `comment`              | -                               | A comment string for the share                                                                 |
+| `comment`              | -                               | A comment string for the share.                                                                 |
 | `create_mode`          | `0664`                          | See the Samba documentation for details.                                                       |
 | `directory_mode`       | `0775`                          | See the Samba documentation for details.                                                       |
 | `include_file`         | -                               | Samba combatible configuration file with options to be included for this share (see below).    |
 | `force_create_mode`    | `0664`                          | See the Samba documentation for details.                                                       |
 | `force_directory_mode` | `0775`                          | See the Samba documentation for details.                                                       |
-| `group`                | `users`                         | The user group files in the share will be added to. (force group)                              |
+| `group`                | `users`                         | The user group files in the share will be added to (share option `force group`).               |
 | `guest_ok`             | -                               | Allow guest access.                                                                            |
 | `name` (required)      | -                               | The name of the share.                                                                         |
-| `owner`                | `root`                          | Set the owner of the path                                                                      |
+| `owner`                | `root`                          | Set the owner of the path.                                                                      |
 | `path`                 | `/{{samba_shares_root}}/{{name}}` | The path to the share directory.                                                               |
-| `public`               | `false`                            | Controls read access for guest users                                                           |
+| `public`               | `false`                            | Controls read access for guest users.                                                           |
 | `read_only`               | -                            | If this parameter is yes, then users of a service may not create or modify files in the service's directory.                        |
-| `setype`               | -                 | The SELinux type of the share directory                                                        |
-| `user`                 | -                               | The user files in the share will be added to. (force user)                                     |
+| `setype`               | -                 | The SELinux type of the share directory.                                                        |
+| `user`                 | -                               | The user files in the share will be added to (share option `force user`).                      |
 | `valid_users`          | -                               | Controls read access for registered users. Use the syntax of the corresponding Samba setting.  |
 | `vfs_objects`          | -                               | See the Samba documentation for details.                                                       |
 | `writable`             | -                               | Synonym for `writeable`.                                                                           |
-| `writeable`             | -                               | Writeable for guests.                                                                           |
+| `writeable`             | -                               | Controls whether this share is writeable for guests.                                         |
 | `write_list`           | -                               | Controls write access for registered users. Use the syntax of the corresponding Samba setting. |
 
 The values for `valid_users` and `write_list` should be a comma separated list of users. Names prepended with `+` or `@` are interpreted as groups. The documentation for the [Samba configuration](https://www.samba.org/samba/docs/man/manpages-3/smb.conf.5.html) has more details on these options.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ A complete overview of share options follows below. Only `name` is required, the
 
 | Option                 | Default                         | Comment                                                                                        |
 | :---                   | :---                            | :---                                                                                           |
-| `browsable`           | -                               | Synonim `browseable`.                                           |
+| `browsable`           | -                               | Synonym for `browseable`.                                           |
 | `browseable`           | -                               | Controls whether this share appears in file browser.                                           |
 | `comment`              | -                               | A comment string for the share                                                                 |
 | `create_mode`          | `0664`                          | See the Samba documentation for details.                                                       |

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -1,3 +1,3 @@
 # Ansible role - `vladgh.samba.server`
 
-Refer to this collection's [README](/README.md) file
+Refer to this collection's [README](../../README.md) file.

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -117,7 +117,7 @@
   path = {{ share.path | default([samba_shares_root,share.name] | join('/')) }}
   public = {{ share.public | default('no') | bool | ternary('yes', 'no') }}
 {% if share.valid_users is defined and share.valid_users %}
-  valid users= {{ share.valid_users }}
+  valid users = {{ share.valid_users }}
 {% endif %}
 {% if share.write_list is defined and share.write_list %}
   write list = {{ share.write_list }}


### PR DESCRIPTION
The first commit is about fixing the missing spacing in the template for the option `valid users`. It resulted in `valid users= user1 +group2` and was inconsistent with the other options. 

The other commits are about enhancing the documentation in regards of consistency and readability.

See commit annotations for detailed descriptions. I made small commits so we can discard individual changes if they are unwelcome.

### commits

commit 012fd257b48db23f96d8e8a45b69c0fac972f6f0

    Fix spacing for valid users option in template

commit 6dc4922d10edf44ef30fc30110c0b267a9615ea3

    Fix typo in "Synonym"
    
    Also expands "Synonym" to "Synonym for" to be consistence with writable
    row.

commit dacfe68a6fbbc342bc1521e2fbbc13b9afe0e24b

    Unify punctuation in role variable documentation
    
    Additionally a few wordings where adjusted.

commit a3ccd0572c514d7402ae31db7e57c7ca2a5c239a

    Format tables in role variable documentation
    
    This enhances readability when opening the file in an editor.
    
    Formatting done automatically with dhruvasagar/vim-table-mode plugin.

commit 32caf8a1d23b82325bc71d6b9780668980533098

    Use relative markdown link to collection README.md
    
    While the /README.md notation works for GitHub it may not work for other
    git platforms / web-interfaces.
    
    As it is considered best practice to locally install the collection
    into the folder of the root playbook that link should be as compatible
    as possible.
    
    Additionally a period is appended to the end of the sentence.

### Punctuation and Braces

I was unsure regarding punctuation in braces. A quick online search has brought me to [this reddit post](https://www.reddit.com/r/writing/comments/th0v05/how_to_put_the_period_after_a_complete_sentence/). There it is stated that the period needs to be inside the brace if it is a whole sentence (e. g. `samba_cups_server`). If the information in the braces is a small additional information, which complete the sentence, the period need to be placed after the braces (e. g. `samba_global_include`).