### PR TITLE
Add hosts allow / deny option for samba shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ samba_shares:
     guest_ok: true
     write_list: tomcat
     group: tomcat
+    hosts_allow:
+      - 192.168.178.
+      - 192.168.1.1
+    hosts_deny:
+      - 192.168.4.
+      - 192.168.1.2
 ```
 
 A complete overview of share options follows below. Only `name` is required, the rest is optional.
@@ -239,6 +245,8 @@ A complete overview of share options follows below. Only `name` is required, the
 | `writable`             | -                                 | Synonym for `writeable`.                                                                                     |
 | `writeable`            | -                                 | Controls whether this share is writeable for guests.                                                         |
 | `write_list`           | -                                 | Controls write access for registered users. Use the syntax of the corresponding Samba setting.               |
+| `hosts_allow`          | -                                 | Limits access to a list of IP addresses or dns names. Use the syntax of the corresponding Samba setting.     |
+| `hosts_deny`           | -                                 | Denies access for a list of IP addresses or dns names. Use the syntax of the corresponding Samba setting.    |
 
 The values for `valid_users` and `write_list` should be a comma separated list of users. Names prepended with `+` or `@` are interpreted as groups. The documentation for the [Samba configuration](https://www.samba.org/samba/docs/man/manpages-3/smb.conf.5.html) has more details on these options.
 

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -160,6 +160,12 @@
 {% if share.include_file is defined and share.include_file %}
   include = {{ samba_configuration_dir }}/{{ share.include_file | basename }}
 {% endif %}
+{% if share.hosts_allow is defined and share.hosts_allow | length > 0 %}
+  hosts allow = {{ share.hosts_allow | join(' ') }}
+{% endif %}
+{% if share.hosts_deny is defined and share.hosts_deny | length > 0 %}
+  hosts deny = {{ share.hosts_deny | join(' ') }}
+{% endif %}
 
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This PR adds the options `hosts_allow` and `hosts_deny` to the 'samba_shares' object dictionary, to allow limiting access to shares to certain IP address or networks.

More info on these options: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#ALLOWHOSTS