### PR TITLE
`ansible_hostname` is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,43 +95,43 @@ Alternatively, you can directly import the existing playbook:
 
 ## Server Role Variables
 
-| Variable                       | Default                  | Comments                                                                                                                     |
-| :---                           | :---                     | :---                                                                                                                         |
-| `samba_apple_extensions`       | `true`                   | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below).         |
-| `samba_create_varwww_symlinks` | `false`                  | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform.)         |
-| `samba_cups_server`            | `localhost:631`          | Value for the global option `cups server`. (Only needed when `samba_printer_type` is "cups".)                                |
-| `samba_enable_netbios`         | `true`                   | When false, the NMB daemon is disabled by setting `disable netbios` to `yes`. This overrides other NetBIOS related settings. |
-| `samba_domain_master`          | `true`                   | When true, smbd enables WAN-wide browse list collation.                                                                      |
-| `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to `[global]` section (see below).
-| `samba_global_config_extras`   | -                        | Samba-compatible configuration directives to be added to the [global] section (see below).
-| `samba_guest_account`          | -                        | Guest account for unknown users.                                                                                             |
-| `samba_homes_include`          | -                        | Samba-compatible configuration file with options to be loaded to `[homes]` section (see below).                              |
-| `samba_interfaces`             | `[]`                     | List of network interfaces used for browsing, name registration, etc.                                                        |
-| `samba_load_homes`             | `false`                  | When true, user home directories are accessible.                                                                             |
-| `samba_load_printers`          | `false`                  | When true, printers attached to the host are shared.                                                                         |
-| `samba_local_master`           | `true`                   | When true, nmbd will try & become local master of the subnet.                                                                |
-| `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                         |
-| `samba_log_size`               | `5000`                   | Set the maximum size of the log file.                                                                                        |
-| `samba_log_level`              | `0`                      | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
-| `samba_map_to_guest`           | `Never`                  | Behaviour when unregistered users access the shares.                                                                         |
-| `samba_mitigate_cve_2017_7494` | `true`                   | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
-| `samba_mdns_name`              | `netbios`                | The name advertised via multicast DNS.                                                                                       |
-| `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |
-| `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                                   |
-| `samba_preferred_master`       | `true`                   | When true, indicates nmbd is a preferred master browser for workgroup.                                                       |
-| `samba_realm`                  | -                        | Realm domain name.                                                                                                           |
-| `samba_printer_type`           | `cups`                   | value for the global option `printing` and `printcap name`.                                                                  |
-| `samba_security`               | `user`                   | Samba security setting.                                                                                                      |
-| `samba_server_max_protocol`    | -                        | Specify a maximum protocol version offered by the server.                                                                    |
-| `samba_server_min_protocol`    | -                        | Specify a minimum protocol version offered by the server.                                                                    |
-| `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                                                                               |
-| `samba_shares_root`            | `/srv/shares`            | Directories for the shares are created under this directory.                                                                 |
-| `samba_manage_directories`     | `true`                   | Create the directories, and manage the permissions/ownership, of the shares root and the shares under it.                    |
-| `samba_shares`                 | `[]`                     | List of dicts containing share definitions. See below for details.                                                           |
-| `samba_username_map`           | `[]`                     | Makes username map configurable.                                                                                             |
-| `samba_users`                  | `[]`                     | List of dicts defining users that can access shares.                                                                         |
-| `samba_wins_support`           | `true`                   | When true, Samba will act as a WINS server.                                                                                  |
-| `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                                                                                |
+| Variable                       | Default                           | Comments                                                                                                                     |
+| :----------------------------- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `samba_apple_extensions`       | `true`                            | When true, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below).         |
+| `samba_create_varwww_symlinks` | `false`                           | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform.)         |
+| `samba_cups_server`            | `localhost:631`                   | Value for the global option `cups server`. (Only needed when `samba_printer_type` is "cups".)                                |
+| `samba_enable_netbios`         | `true`                            | When false, the NMB daemon is disabled by setting `disable netbios` to `yes`. This overrides other NetBIOS related settings. |
+| `samba_domain_master`          | `true`                            | When true, smbd enables WAN-wide browse list collation.                                                                      |
+| `samba_global_include`         | -                                 | Samba-compatible configuration file with options to be loaded to `[global]` section (see below).                             |
+| `samba_global_config_extras`   | -                                 | Samba-compatible configuration directives to be added to the [global] section (see below).                                   |
+| `samba_guest_account`          | -                                 | Guest account for unknown users.                                                                                             |
+| `samba_homes_include`          | -                                 | Samba-compatible configuration file with options to be loaded to `[homes]` section (see below).                              |
+| `samba_interfaces`             | `[]`                              | List of network interfaces used for browsing, name registration, etc.                                                        |
+| `samba_load_homes`             | `false`                           | When true, user home directories are accessible.                                                                             |
+| `samba_load_printers`          | `false`                           | When true, printers attached to the host are shared.                                                                         |
+| `samba_local_master`           | `true`                            | When true, nmbd will try & become local master of the subnet.                                                                |
+| `samba_log`                    | -                                 | Set the log file. If left undefined, logging is done through syslog.                                                         |
+| `samba_log_size`               | `5000`                            | Set the maximum size of the log file.                                                                                        |
+| `samba_log_level`              | `0`                               | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
+| `samba_map_to_guest`           | `Never`                           | Behaviour when unregistered users access the shares.                                                                         |
+| `samba_mitigate_cve_2017_7494` | `true`                            | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
+| `samba_mdns_name`              | `netbios`                         | The name advertised via multicast DNS.                                                                                       |
+| `samba_netbios_name`           | `{{ ansible_facts['hostname'] }}` | The NetBIOS name of this server.                                                                                             |
+| `samba_passdb_backend`         | `tdbsam`                          | Password database backend.                                                                                                   |
+| `samba_preferred_master`       | `true`                            | When true, indicates nmbd is a preferred master browser for workgroup.                                                       |
+| `samba_realm`                  | -                                 | Realm domain name.                                                                                                           |
+| `samba_printer_type`           | `cups`                            | value for the global option `printing` and `printcap name`.                                                                  |
+| `samba_security`               | `user`                            | Samba security setting.                                                                                                      |
+| `samba_server_max_protocol`    | -                                 | Specify a maximum protocol version offered by the server.                                                                    |
+| `samba_server_min_protocol`    | -                                 | Specify a minimum protocol version offered by the server.                                                                    |
+| `samba_server_string`          | `fileserver %m`                   | Comment string for the server.                                                                                               |
+| `samba_shares_root`            | `/srv/shares`                     | Directories for the shares are created under this directory.                                                                 |
+| `samba_manage_directories`     | `true`                            | Create the directories, and manage the permissions/ownership, of the shares root and the shares under it.                    |
+| `samba_shares`                 | `[]`                              | List of dicts containing share definitions. See below for details.                                                           |
+| `samba_username_map`           | `[]`                              | Makes username map configurable.                                                                                             |
+| `samba_users`                  | `[]`                              | List of dicts defining users that can access shares.                                                                         |
+| `samba_wins_support`           | `true`                            | When true, Samba will act as a WINS server.                                                                                  |
+| `samba_workgroup`              | `WORKGROUP`                       | Name of the server workgroup.                                                                                                |
 
 ### Defining users
 

--- a/roles/server/templates/smb.conf.j2
+++ b/roles/server/templates/smb.conf.j2
@@ -2,7 +2,7 @@
 
 [global]
   # Server information
-  netbios name = {% if samba_netbios_name is defined and samba_netbios_name %}{{ samba_netbios_name }}{% else %}{{ ansible_hostname }}{% endif +%}
+  netbios name = {% if samba_netbios_name is defined and samba_netbios_name %}{{ samba_netbios_name }}{% else %}{{ ansible_facts['hostname'] }}{% endif +%}
   mdns name = {% if samba_mdns_name is defined and samba_mdns_name %}{{ samba_mdns_name }}{% else %}netbios{% endif +%}
   workgroup = {{ samba_workgroup }}
 {% if samba_realm is defined and samba_realm %}


### PR DESCRIPTION
This is a follow up of #202. Thanks for your PR to solve it! Unfortunately there is still one injected variable in use in file `smb.conf.j2`, which is `ansible_hostname`.