### PR TITLE
[TASK] OPS-79: Implement extended ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Alternatively, you can directly import the existing playbook:
 | `samba_users`                  | `[]`                              | List of dicts defining users that can access shares.                                                                         |
 | `samba_wins_support`           | `true`                            | When true, Samba will act as a WINS server.                                                                                  |
 | `samba_workgroup`              | `WORKGROUP`                       | Name of the server workgroup.                                                                                                |
+| `samba_acl_enabled`            | `true`                            | Enable extended ACL on samba shares.                                                                                         |
+| `samba_acl_mountpoints`        | `[]`                              | List of fstab mountpoints which need to be mounted with extended ACL enabled.                                                |
 
 ### Defining users
 
@@ -247,8 +249,27 @@ A complete overview of share options follows below. Only `name` is required, the
 | `write_list`           | -                                 | Controls write access for registered users. Use the syntax of the corresponding Samba setting.               |
 | `hosts_allow`          | -                                 | Limits access to a list of IP addresses or dns names. Use the syntax of the corresponding Samba setting.     |
 | `hosts_deny`           | -                                 | Denies access for a list of IP addresses or dns names. Use the syntax of the corresponding Samba setting.    |
+| `acl`                  | `{}`                              | List of default ACL permissions to be set on share directory.                                                |
 
 The values for `valid_users` and `write_list` should be a comma separated list of users. Names prepended with `+` or `@` are interpreted as groups. The documentation for the [Samba configuration](https://www.samba.org/samba/docs/man/manpages-3/smb.conf.5.html) has more details on these options.
+
+Example structure of the `acl` field:
+
+```yaml
+- name: username
+  type: user
+  permission: rwx
+  default: true
+- name: groupname
+  type: group
+  permission: r
+  default: true
+- name: mask
+  type: mask
+  permission: rwx
+```
+
+More information in ```man setfacl```
 
 ## Username mapping
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,15 +3,31 @@
   hosts: all
   become: true
   tasks:
+    - name: Create groups
+      ansible.builtin.group:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - testgroup
+        - timemachine
+        - usr1
     - name: Add test users
       ansible.builtin.user:
-        name: "{{ item }}"
-        groups: users
+        name: "{{ item.user }}"
+        group: "{{ item.group }}"
+        groups: "{{ item.groups | default(omit) }}"
         append: true
       loop:
-        - usr1
-        - usr2
-        - timemachine
+        - user: usr1
+          group: users
+        - user: usr2
+          group: users
+        - user: timemachine
+          group: users
+        - user: testuser
+          group: testgroup
+        - user: testuser2
+          group: users
     - name: Include role
       ansible.builtin.include_role:
         name: vladgh.samba.server
@@ -28,6 +44,26 @@
         samba_log_size: 60000
         samba_log_level: '3 passdb:5 auth:10 winbind:2 '
         samba_map_to_guest: Never
+        samba_acl_enabled: true
+        samba_acl_mountpoints:
+          - /
+
+        vault_sambauser_testuser: test
+        vault_sambauser_testuser2: test
+
+        samba_vfs_objects_full_audit:
+          - name: full_audit
+            options:
+              - name: prefix
+                value: "%u|%I|%m|%S"
+              - name: success
+                value: "mkdir rename unlink rmdir pwrite sendfile write read open"
+              - name: failure
+                value: "none"
+              - name: facility
+                value: LOCAL7
+              - name: priority
+                value: NOTICE
         samba_users:
           - name: usr1
             password: usr1
@@ -35,18 +71,24 @@
             password: usr2
           - name: timemachine
             password: timemachine
+          - name: testuser
+            password: "{{ vault_sambauser_testuser }}"
+          - name: testuser2
+            password: "{{ vault_sambauser_testuser2 }}"
         samba_username_map:
           - from: 'User Two'
             to: usr2
         samba_shares_root: /srv/samba
         samba_shares:
           - name: restrictedshare
+            acl: []
           - name: privateshare
             comment: 'Only readable/writeable by usr1'
             valid_users: usr1
             write_list: usr1
             group: usr1
             browseable: false
+            acl: []
           - name: protectedshare
             public: true
             comment: 'Public, but only writeable by usr2'
@@ -55,17 +97,20 @@
             group: users
             browseable: true
             include_file: protectedshare-include.conf
+            acl: []
           - name: publicshare
             comment: 'Public share, writeable by all members of group ‘users’'
             public: true
             write_list: +users
             group: users
             browseable: true
+            acl: []
           - name: guestshare
             comment: 'Share accessible for guests'
             guest_ok: true
             writeable: true
             browseable: true
+            acl: []
           - name: TimeMachine
             comment: 'Share useable as a TimeMachine backup target on MacOS'
             vfs_objects:
@@ -89,7 +134,25 @@
             public: false
             guest_ok: false
             browseable: false
+            acl: []
             create_mask: '0600'
+          - name: testshare
+            comment: share
+            path: /data/testshare
+            owner: testuser
+            group: testgroup
+            mode: "0775"
+            acl:
+              - name: testuser2
+                type: user
+                permission: rwx
+                default: true
+              - name: testgroup
+                type: group
+                permission: rwx
+                default: true
+            write_list: testuser testuser2
+            vfs_objects: "{{ samba_vfs_objects_full_audit }}"
           - name: NetworkRestrictedShare
             comment: 'Only allow / deny specific hosts'
             hosts_allow:
@@ -98,3 +161,4 @@
             hosts_deny:
               - 192.168.4.
               - 192.168.1.2
+            acl: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,3 +22,10 @@ provisioner:
     host_vars:
       instance:
         ansible_user: root
+# Runs the verify.yml playbook. Testinfra is also a supported method.
+# Check the Molecule documention for more information.
+verifier:
+  name: testinfra
+  options:
+    v: 1
+    sudo: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# :Project:   endian.firewalld ansible role - unittests
+# :Created:   Tue 11 May 2021 22:05:46 CEST
+# :Author:    Peter Warasin <peter@endian.com>
+# :License:   GPLv2
+# :Copyright: © 2021 Endian s.r.l.
+#
+
+
+"""
+test_default.py - default unittest file.
+
+This file contains unittests using testinfra used to test if the
+ansible role does what we wanted that it would do.
+"""
+
+
+def test_share_directory(host):
+    """
+    Test if the cron script is installed correctly.
+
+    This test method checks if the cron script is copied
+    correctly to the test system.
+
+    :param host:     the link to the testinfra host provided by fixture
+    :type  host:     Host object
+    """
+    file1 = host.file("/data/testshare")
+    assert file1.is_directory
+    assert file1.user == "testuser"
+    assert file1.group == "testgroup"
+    assert file1.mode == 0o775
+
+
+def test_facl_on_directory(host):
+    """
+    Test if the testshare directory has the correct facl settings
+
+    :param host:     the link to the testinfra host provided by fixture
+    :type  host:     Host object
+    """
+    file1 = None
+    try:
+        file1 = host.ansible(
+            "command",
+            "getfacl /data/testshare",
+            check=False,
+        )
+    except host.ansible.AnsibleException as exc:
+        assert exc.result["failed"] is True
+        assert exc.result["msg"] == ""
+        return None
+
+    assert file1["stdout_lines"][0] == '# file: data/testshare'
+    assert file1["stdout_lines"][1] == '# owner: testuser'
+    assert file1["stdout_lines"][2] == '# group: testgroup'
+    assert file1["stdout_lines"][3] == 'user::rwx'
+    assert file1["stdout_lines"][4] == 'group::rwx'
+    assert file1["stdout_lines"][5] == 'other::r-x'
+    assert file1["stdout_lines"][7] == 'default:user:testuser2:rwx'
+    assert file1["stdout_lines"][9] == 'default:group:testgroup:rwx'

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -23,3 +23,7 @@ samba_local_master: true
 samba_domain_master: true
 samba_preferred_master: true
 samba_mitigate_cve_2017_7494: true
+
+samba_acl_enabled: false
+samba_acl_mountpoints:
+  - /

--- a/roles/server/tasks/acl.yml
+++ b/roles/server/tasks/acl.yml
@@ -1,0 +1,14 @@
+---
+- name: "samba | ACL | Set extended ACL on shares"
+  ansible.posix.acl:
+    path: "{{ item[0].path }}"
+    entity: "{{ item[1].name }}"
+    etype: "{{ item[1].type }}"
+    permissions: "{{ item[1].permission }}"
+    default: "{{ item[1].default | default(false) }}"
+    state: present
+  with_subelements:
+    - "{{ samba_shares }}"
+    - "acl"
+  when:
+    - samba_acl_enabled | bool

--- a/roles/server/tasks/acltools.yml
+++ b/roles/server/tasks/acltools.yml
@@ -1,0 +1,7 @@
+---
+- name: Install ACL packages
+  package:
+    name: "{{ samba_acl_packages }}"
+    state: present
+  when:
+    - samba_acl_enabled | bool

--- a/roles/server/tasks/assert.yml
+++ b/roles/server/tasks/assert.yml
@@ -1,0 +1,62 @@
+---
+- name: if acl is enabled, samba_acl_mountpoints need to be set
+  assert:
+    that:
+      - samba_acl_mountpoints is defined and samba_acl_mountpoints is iterable
+    msg: "'samba_acl_mountpoints' must be a list of mount points!"
+    quiet: true
+  when:
+    - samba_acl_enabled | bool
+
+- name: if acl is enabled, check if acls are defined
+  assert:
+    that:
+      - item.acl is defined and item.acl is iterable
+    msg: "'acl' field of samba_share '{{ item.name }}' must be a list!"
+    quiet: true
+  with_items:
+    - "{{ samba_shares }}"
+  when:
+    - samba_acl_enabled | bool
+
+- name: if acl is enabled, check if all acls have required fields set
+  assert:
+    that:
+      - item[1].name is defined and item[1].name is string
+      - item[1].type is defined and item[1].type is string
+      - item[1].permission is defined and item[1].permission is string
+    msg: "'acl' of samba_share '{{ item[0].name }}' must be list of of entries \
+    which contain 'name', 'type' and 'permission' field!"
+    quiet: true
+  with_subelements:
+    - "{{ samba_shares }}"
+    - "acl"
+  when:
+    - samba_acl_enabled | bool
+
+- name: if acl is enabled, check if all acls have required fields set
+  assert:
+    that:
+      - item[1].type is defined and item[1].type in samba_acl_types
+    msg: "'acl' type of samba_share '{{ item[0].name }}' must be one of: \
+    '{{ samba_acl_types }}, got '{{ item[1].type | default(omit) }}'!"
+    quiet: true
+  with_subelements:
+    - "{{ samba_shares }}"
+    - "acl"
+  when:
+    - samba_acl_enabled | bool
+
+- name: if acl is enabled, check if all acls have correct permissions set
+  assert:
+    that:
+      - item[1].permission is defined and item[1].permission in samba_acl_permissions
+    msg: "'permission' type of samba_share '{{ item[0].name }}' must be one \
+    of: '{{ samba_acl_permissions }}, got \
+    '{{ item[1].permission | default(omit) }}'!"
+    quiet: true
+  with_subelements:
+    - "{{ samba_shares }}"
+    - "acl"
+  when:
+    - samba_acl_enabled | bool

--- a/roles/server/tasks/fstab.yml
+++ b/roles/server/tasks/fstab.yml
@@ -1,0 +1,15 @@
+---
+- name: "Check if chacl is working on {{ item }}"
+  shell: |
+    chacl -l {{ item }}
+  register:
+    return_chacl
+  changed_when: false
+
+- name: "Remount device {{ item }} and add -o acl"
+  ansible.posix.mount:
+    state: remounted
+    opts: acl
+    path: "{{ item }}"
+  when:
+    - return_chacl.rc != 0

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: include assert
+  ansible.builtin.include_tasks: assert.yml
+
 - name: Include OS specific variables
   ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
   vars:
@@ -167,3 +170,27 @@
   when: samba_users is defined and samba_users | length > 0
   changed_when: "'Added user' in create_user_output.stdout"
   tags: samba
+
+# this need to be installed before modification to fstab, because fstab.yml
+# needs chacl tool installed
+- name: include installation of acl tools
+  ansible.builtin.include_tasks: acltools.yml
+  when:
+    - samba_acl_enabled | bool
+  tags:
+    - acl
+
+- name: include modifications in fstab
+  ansible.builtin.include_tasks: fstab.yml
+  with_items: "{{ samba_acl_mountpoints }}"
+  when:
+    - samba_acl_enabled | bool
+  tags:
+    - acl
+
+- name: include configuration of ACL
+  ansible.builtin.include_tasks: acl.yml
+  when:
+    - samba_acl_enabled | bool
+  tags:
+    - acl

--- a/roles/server/vars/main.yml
+++ b/roles/server/vars/main.yml
@@ -1,0 +1,14 @@
+---
+samba_acl_types:
+  - user
+  - group
+  - mask
+samba_acl_permissions:
+  - r
+  - w
+  - x
+  - rw
+  - rx
+  - wx
+  - rwx
+  

--- a/roles/server/vars/os_Archlinux.yml
+++ b/roles/server/vars/os_Archlinux.yml
@@ -13,3 +13,6 @@ smb_service: smb
 nmb_service: nmb
 
 samba_www_documentroot: /var/www
+
+samba_acl_packages:
+  - acl

--- a/roles/server/vars/os_Debian.yml
+++ b/roles/server/vars/os_Debian.yml
@@ -14,3 +14,6 @@ smb_service: smbd
 nmb_service: nmbd
 
 samba_www_documentroot: /var/www
+
+samba_acl_packages:
+  - acl

--- a/roles/server/vars/os_RedHat.yml
+++ b/roles/server/vars/os_RedHat.yml
@@ -13,3 +13,6 @@ smb_service: smb
 nmb_service: nmb
 
 samba_www_documentroot: /var/www/html
+
+samba_acl_packages:
+  - acl


### PR DESCRIPTION
This modification adds the possibility to set extended ACLs on directories so to have a better control on access inside samba shares.

Example:

        samba_shares:
          - name: testshare
            comment: share
            path: /data/testshare
            owner: testuser
            group: testgroup
            mode: "0775"
            acl:
              - name: testuser2
                type: user
                permission: rwx
                default: true
              - name: testgroup
                type: group
                permission: rwx
                default: true

